### PR TITLE
Moved mixins and placeholders below theme variables

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -3,12 +3,6 @@
 // Foundation utilities
 @import '../bower_components/foundation-sites/scss/util/_util';
 
-// Internal Mixins
-@import 'helpers/mixins/_mixins';
-
-// Placeholders
-@import 'helpers/_placeholders';
-
 // Foundation Global Stuff
 @import '../bower_components/foundation-sites/scss/_global';
 
@@ -59,6 +53,12 @@
 
 // Overrides
 @import 'helpers/_theme-variables';
+
+// Internal Mixins
+@import 'helpers/mixins/_mixins';
+
+// Placeholders
+@import 'helpers/_placeholders';
 
 // Foundation Componnet mixins
 @include foundation-global-styles;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brei-sass-boilerplate",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "https://github.com/BarkleyREI/brei-sass-boilerplate",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
So we can use colors and other overrides inside the mixins and
placeholders.